### PR TITLE
Stop animation timer when all animations are complete

### DIFF
--- a/SDUI/Animation/AnimationEngine.cs
+++ b/SDUI/Animation/AnimationEngine.cs
@@ -224,8 +224,8 @@ public class AnimationEngine
             var direction = animationDirections[i];
             var progress = animationProgresses[i];
 
-            if (direction == AnimationDirection.InOutIn || 
-                direction == AnimationDirection.InOutRepeatingIn || 
+            if (direction == AnimationDirection.InOutIn ||
+                direction == AnimationDirection.InOutRepeatingIn ||
                 direction == AnimationDirection.InOutRepeatingOut)
                 return;
 
@@ -235,6 +235,7 @@ public class AnimationEngine
                 return;
         }
 
+        Running = false;
         OnAnimationFinished?.Invoke(this);
     }
 


### PR DESCRIPTION
Previously, the Running flag was not set to false after all animations finished, causing the animation timer to continue ticking indefinitely and resulting in high CPU usage.